### PR TITLE
DevOPS : Docker image build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,28 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build Docker image
+        run: |
+          docker-compose build
+
+      - name: Push Docker image
+        run: |
+          docker-compose push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-FROM node:22
+# Use the official Node.js image as the base image
+FROM node:14
 
-WORKDIR /app 
+# Set the working directory
+WORKDIR /usr/src/app
 
-COPY package.json /app
+# Copy package.json and package-lock.json
+COPY package*.json ./
 
+# Install dependencies
 RUN npm install
 
-RUN npm install nodemon -g
+# Copy the rest of the application code
+COPY . .
 
-COPY . /app
+# Add wait-for-it script
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/src/app/wait-for-it.sh
+RUN chmod +x /usr/src/app/wait-for-it.sh
 
-CMD ["npm", "start"]
+# Expose the port your app runs on
+EXPOSE 3000
+
+# Start the application
+CMD ["./wait-for-it.sh", "mongo:27017", "--", "npm", "start"]
 
 
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing a Docker image, and updates the `Dockerfile` to improve clarity and functionality.

New GitHub Actions workflow:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR1-R28): Added a new workflow configuration to build and push a Docker image on pushes to the `main` branch. This includes steps for checking out the code, logging into Docker Hub, building the Docker image, and pushing it to Docker Hub.

Updates to `Dockerfile`:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R24): Changed the base image from `node:22` to `node:14`, added comments for clarity, set the working directory to `/usr/src/app`, and included the `wait-for-it` script to ensure the application waits for the MongoDB service before starting.