### PR TITLE
Fix : Mongo Db instlling Fixed

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,9 +40,14 @@ jobs:
           sudo apt-get install -y docker.io
           sudo systemctl start docker
           sudo usermod -aG docker ubuntu
-          sudo apt-get install -y mongodb
-          sudo systemctl start mongodb
-          sudo systemctl enable mongodb
+
+          # Install MongoDB
+          wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+          sudo apt-get update -y
+          sudo apt-get install -y mongodb-org
+          sudo systemctl start mongod
+          sudo systemctl enable mongod
         EOF
 
     - name: Deploy application


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-image.yml` file to update the MongoDB installation process. The most important changes are as follows:

Improvements to MongoDB installation:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL43-R50): Replaced the existing MongoDB installation commands with a more robust method that includes adding the MongoDB GPG key, updating the repository, and installing `mongodb-org` instead of `mongodb`.